### PR TITLE
add installation command of dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ To install the development version in R, use
 
 ```r
 library(devtools)  
+install_github("hallucigenia-sparsa/seqtime")  
 install_github("ramellose/CoNetinR")  
 library(CoNetinR)  
 ```


### PR DESCRIPTION
Installation failed for me without pre-installing `seqtime` from its github repo.